### PR TITLE
Create basic_service_restart.yaml

### DIFF
--- a/packs/linux-ops/actions/basic_restart_service.meta.yaml
+++ b/packs/linux-ops/actions/basic_restart_service.meta.yaml
@@ -1,0 +1,19 @@
+---
+  name: "restart_service"
+  pack: "linux-ops"
+  runner_type: "mistral-v2"
+  enabled: true
+  parameters: 
+    hostname: 
+      type: "string"
+      description: "The host to restart the service on."
+      required: true
+    service: 
+      type: "string"
+      description: "The service to be restarted."
+      required: true
+    check: 
+      type: "string"
+      description: "The sensu check name to be silenced."
+  ref: "default.restart_service"
+  entry_point: "workflows/restart_service.yaml"

--- a/packs/linux-ops/actions/workflows/basic_restart_service.yaml
+++ b/packs/linux-ops/actions/workflows/basic_restart_service.yaml
@@ -1,7 +1,7 @@
 ---
 version: '2.0'
 
-default.restart_service:
+linux-ops.restart_service:
   input:
     - hostname
     - service

--- a/packs/linux-ops/actions/workflows/basic_service_restart.yaml
+++ b/packs/linux-ops/actions/workflows/basic_service_restart.yaml
@@ -1,0 +1,60 @@
+---
+version: '2.0'
+
+default.restart_service:
+  input:
+    - hostname
+    - service
+    - check
+  tasks:
+    restart_service:
+      # [255, 128]
+      action: core.remote_sudo
+      input:
+        hosts: <% $.hostname %>
+        cmd: service <% $.service %> restart
+      on-success:
+        - sleep
+      on-error:
+        - failure_message
+    sleep:
+      # [185, 230]
+      action: core.local
+      input:
+        cmd: sleep 5
+      on-success:
+        - check_service
+      on-error:
+        - failure_message
+    check_service:
+      # [115, 332]
+      action: core.remote_sudo
+      input:
+        hosts: <% $.hostname %>
+        cmd: service <% $.service %> status
+      on-success:
+        - success_message
+      on-error:
+        - failure_message
+    success_message:
+      # [105, 434]
+      action: slack.chat.postMessage
+      input:
+        text: <% $.service %> was successfully restarted on <% $.hostname %>.
+        channel: "#opstown"
+    failure_message:
+      # [375, 434]
+      action: slack.chat.postMessage
+      input:
+        text: <% $.service %> could not be restarted on %< $.hostname %>!
+        channel: "#opstown"
+    sensu_silence:
+      # [255, 26]
+      action: sensu.silence
+      input:
+        client: <% $.hostname %>
+        check: <% $.check %>
+      on-success:
+        - restart_service
+      on-error:
+        - restart_service

--- a/packs/linux-ops/rules/basic_restart_service_hubot.yaml
+++ b/packs/linux-ops/rules/basic_restart_service_hubot.yaml
@@ -1,0 +1,22 @@
+---
+  action: 
+    parameters: 
+      check: "{{trigger.check.name}}"
+      hostname: "{{trigger.client.name}}"
+      service: "hubot"
+    ref: "default.restart_service"
+  criteria: 
+    trigger.check.name: 
+      pattern: "process_hubot"
+      type: "matchregex"
+  enabled: true
+  name: "restart_service"
+  pack: "default"
+  tags: []
+  trigger: 
+    parameters: {}
+    ref: "sensu.event_handler"
+    type: "sensu.event_handler"
+  type: 
+    parameters: {}
+    ref: "standard"


### PR DESCRIPTION
Adds a basic service restart workflow and an example rule that will fire it for sensu process alerts about the hubot process being down.
